### PR TITLE
Don't fail on ignored event

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,5 +61,4 @@ if [[ "$action" == "submitted" ]] && [[ "$state" == "approved" ]]; then
   label_when_approved
 else
   echo "Ignoring event ${action}/${state}"
-  exit 78
 fi


### PR DESCRIPTION
This change prevents the action to fail in case on ignored events (such as a review dismissed).