### PR TITLE
Use URL percent encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
         APPROVALS: "2"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ADD_LABEL: "approved"
-        REMOVE_LABEL: "awaiting review"
+        REMOVE_LABEL: "awaiting%20review"
 ```
 
 ## Demo


### PR DESCRIPTION
Because of calling GitHub REST API, it does work well with not space but %20.
I fixed the example in README.