### PR TITLE
Use Alpine Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.6-slim
+FROM alpine:3.10.3
 
 LABEL "com.github.actions.name"="Label approved pull requests"
 LABEL "com.github.actions.description"="Auto-label pull requests that have a specified number of approvals"
@@ -10,9 +10,7 @@ LABEL repository="http://github.com/pullreminders/label-when-approved-action"
 LABEL homepage="http://github.com/pullreminders/label-when-approved-action"
 LABEL maintainer="Abi Noda <abi@pullreminders.com>"
 
-RUN apt-get update && apt-get install -y \
-    curl \
-    jq
+RUN apk add --no-cache bash curl jq
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The Alpine Docker image is much smaller compared to the Debian one (~5.5MB vs 55MB) and generally package installation is faster. With this changes we should be able to speedup the image build phase and thus to make the overall Action execution faster.

Related to #6.