### PR TITLE
Update option name for base64

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ label_when_approved() {
   approvals=0
 
   for r in $reviews; do
-    review="$(echo "$r" | base64 --decode)"
+    review="$(echo "$r" | base64 -d)"
     rState=$(echo "$review" | jq --raw-output '.state')
 
     if [[ "$rState" == "APPROVED" ]]; then


### PR DESCRIPTION
The [change](https://github.com/pullreminders/label-when-approved-action/commit/05670ebf75330290ef7c4ebd7f360bfd1e4eb417) from Debian to Alpine seems like it broke the `entrypoint.sh` script.

`base64` on alpine expect the `-d` instead of `--decode`.