### PR TITLE
Update README.md to point to the latest tag instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Label when approved
-      uses: pullreminders/label-when-approved-action@master
+      uses: pullreminders/label-when-approved-action@v1.0.4
       env:
         APPROVALS: "2"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Using a tag is a more safer as we avoid breaking people's actions in case we push bad commits.